### PR TITLE
Change spl_size for PX30

### DIFF
--- a/tools/rkcommon.c
+++ b/tools/rkcommon.c
@@ -132,7 +132,7 @@ static struct spl_info spl_infos[] = {
 	{ "rk3328", "RK32", 0x8000 - 0x800, false, RK_HEADER_V1 },
 	{ "rk3368", "RK33", 0x8000 - 0x1000, false, RK_HEADER_V1 },
 	{ "rk3399", "RK33", 0x30000 - 0x2000, false, RK_HEADER_V1 },
-	{ "px30", "RK33", 0x2800, false, RK_HEADER_V1 },
+	{ "px30", "RK33", 0x3000, false, RK_HEADER_V1 },
 	{ "rv1108", "RK11", 0x1800, false, RK_HEADER_V1 },
 	{ "rv1126", "110B", 0x10000 - 0x1000, false, RK_HEADER_V1 },
 	{ "rk1808", "RK18", 0x200000 - 0x2000, false, RK_HEADER_V1 },


### PR DESCRIPTION
Seems that we need SPL size of at least 12K to solve this issue:  https://github.com/JeffyCN/mirrors/issues/3
@keveryang mentioned 10K SRAM size here: [cab28f4](https://github.com/JeffyCN/mirrors/commit/cab28f403dae8ca7690a93e8ff7433749b79e91f#diff-a574ea9d0ea21f8e37bbe06be8c06fc23e434824ceec520f39397579f7de727d)
But this doesn't seem to be enough. (see issue)