### PR TITLE
rockchipmpp: allow DMABuf sink caps for mppjpegenc

### DIFF
--- a/gst/rockchipmpp/gstmppdec.c
+++ b/gst/rockchipmpp/gstmppdec.c
@@ -443,15 +443,12 @@ gst_mpp_dec_update_video_info (GstVideoDecoder * decoder, GstVideoFormat format,
   }
 
   if (self->dma_feature) {
-    GstCaps *tmp_caps = gst_caps_copy (output_state->caps);
-    gst_caps_set_features (tmp_caps, 0,
+    /*
+     * Keep output_state->caps fixed for gst_pad_set_caps(), and force
+     * DMABuf memory feature when requested by dma-feature=true.
+     */
+    gst_caps_set_features (output_state->caps, 0,
         gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DMABUF, NULL));
-
-    /* HACK: Expose dmabuf feature when the subset check is hacked */
-    if (gst_caps_is_subset (tmp_caps, output_state->caps))
-      gst_caps_replace (&output_state->caps, tmp_caps);
-
-    gst_caps_unref (tmp_caps);
   }
 
   *info = output_state->info;

--- a/gst/rockchipmpp/gstmppjpegenc.c
+++ b/gst/rockchipmpp/gstmppjpegenc.c
@@ -75,7 +75,11 @@ static GstStaticPadTemplate gst_mpp_jpeg_enc_sink_template =
 GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("video/x-raw,"
+    GST_STATIC_CAPS (
+        "video/x-raw,"
+        "format = (string) { " MPP_ENC_FORMATS " }, "
+        GST_MPP_JPEG_ENC_SIZE_CAPS ";"
+        "video/x-raw(memory:DMABuf),"
         "format = (string) { " MPP_ENC_FORMATS " }, "
         GST_MPP_JPEG_ENC_SIZE_CAPS));
 


### PR DESCRIPTION
## Technical details for review

This PR contains 2 related changes to improve DMABuf interoperability in `rockchipmpp`:

1. `4580ced`  
   `rockchipmpp: allow DMABuf sink caps for mppjpegenc`
2. `568869c`  
   `rockchipmpp: fix dmabuf caps negotiation for mppvideodec`

## 1) Problem statement

### A. `mppjpegenc` sink caps missing DMABuf
- `mppjpegenc` sink pad previously advertised only `video/x-raw`.
- Pipelines that explicitly require DMABuf memory feature on encoder input (e.g. zero-copy paths) could fail caps negotiation.

### B. `mppvideodec` with `dma-feature=true` could still fail negotiation
- Real pipeline case:
  `... ! mppvideodec dma-feature=true ! video/x-raw(memory:DMABuf),format=NV12 ! ...` (input `.mp4`)
- Failure observed: `not-negotiated` from demux/queue path.
- This happened despite `dma-feature=true`, due to how output caps were being transformed/propagated during negotiation.

## 2) Root cause analysis

### A. Encoder side
- `mppjpegenc` sink template did not expose `video/x-raw(memory:DMABuf)`.
- Downstream/upstream strict capsfilters with memory feature could not match.

### B. Decoder side
- In `gst_mpp_dec_update_video_info()` (`gst/rockchipmpp/gstmppdec.c`), DMABuf exposure logic relied on a subset/hack path.
- An intermediate approach that created multi-structure caps can break assumptions in `gst_pad_set_caps()` path where fixed caps are expected at that step.
- Result: negotiation failure surfaced upstream as internal data stream error (`not-negotiated`).

## 3) Implementation details

### A. `mppjpegenc` change
- Sink pad template now also advertises `video/x-raw(memory:DMABuf)` variant.
- Existing `video/x-raw` support is preserved (no removal of system-memory path).

### B. `mppvideodec` change
- File: `gst/rockchipmpp/gstmppdec.c`
- Function: `gst_mpp_dec_update_video_info()`
- When `self->dma_feature` is enabled:
  - Set memory feature directly on `output_state->caps`:
    `GST_CAPS_FEATURE_MEMORY_DMABUF`
  - Keep caps fixed in that negotiation step.
- This avoids unstable subset/append behavior and ensures deterministic DMABuf caps propagation.

## 4) Behavioral impact (before vs after)

### Before
- `mppjpegenc`: strict DMABuf sink caps often failed to negotiate.
- `mppvideodec dma-feature=true`: could still fail with DMABuf capsfilter (`not-negotiated`) for MP4/H.264 playback paths.

### After
- `mppjpegenc` accepts both system-memory and DMABuf raw video input caps.
- `mppvideodec` with `dma-feature=true` negotiates correctly with:
  `video/x-raw(memory:DMABuf),format=NV12`.
- Verified caps on decoder src show explicit DMABuf memory feature.

## 5) Validation performed

### Environment
- RK3588 target
- Rebuilt plugin from this branch and loaded via local plugin path.

### Runtime check
- `gst-inspect-1.0 mppvideodec` shows DMABuf variants in src caps.
- Pipeline tested successfully to EOS:
  ```bash
  GST_PLUGIN_PATH=$HOME/.local/lib/aarch64-linux-gnu/gstreamer-1.0 \
  gst-launch-1.0 -e -v \
    filesrc location=/path/to/input.mp4 \
    ! qtdemux name=demux demux.video_0 \
    ! queue ! h264parse \
    ! mppvideodec dma-feature=true \
    ! "video/x-raw(memory:DMABuf),format=NV12" \
    ! mppjpegenc !
    ! fakesink sync=false
