### PR TITLE
rockchipmpp: fix packet/buffer lifecycle on frequent pipeline restarts

### DIFF
--- a/gst/rkximage/ximagesink.c
+++ b/gst/rkximage/ximagesink.c
@@ -1233,7 +1233,7 @@ gst_x_image_sink_ximage_put (GstRkXImageSink * ximagesink, GstBuffer * buf)
   }
 
   gst_video_sink_center_rect (src, dst, &result, TRUE);
-  if (!self->keep_aspect)
+  if (!ximagesink->keep_aspect)
     result = dst;
 
   result.x += ximagesink->render_rect.x;

--- a/gst/rockchipmpp/gstmppallocator.c
+++ b/gst/rockchipmpp/gstmppallocator.c
@@ -267,14 +267,19 @@ gst_mpp_allocator_free (GstAllocator * allocator, GstMemory * gmem)
 {
   GstMppAllocator *self = GST_MPP_ALLOCATOR (allocator);
 
-  /* Avoid caching external buffers */
+  /* Call parent free FIRST: it triggers qdata destroy -> gst_mpp_mem_destroy
+   * -> mpp_buffer_put, dropping the MppBuffer refcount to 0.
+   * After this, ext_group's buffer has refcount==0 and can be cleared.
+   * NOTE: allocator is still alive here because _gst_memory_free calls
+   * gst_object_unref(allocator) AFTER allocator->free() returns. */
+  GST_ALLOCATOR_CLASS (parent_class)->free (allocator, gmem);
+
+  /* Now the buffer has refcount==0 and can actually be removed from ext_group. */
   mpp_buffer_group_clear (self->ext_group);
 
   /* Clear cached buffers */
   if (!self->cacheable)
     mpp_buffer_group_clear (self->group);
-
-  GST_ALLOCATOR_CLASS (parent_class)->free (allocator, gmem);
 }
 
 GstAllocator *

--- a/gst/rockchipmpp/gstmppdec.c
+++ b/gst/rockchipmpp/gstmppdec.c
@@ -63,6 +63,7 @@ G_DEFINE_ABSTRACT_TYPE (GstMppDec, gst_mpp_dec, GST_TYPE_VIDEO_DECODER);
 static gboolean DEFAULT_PROP_IGNORE_ERROR = TRUE;
 static gboolean DEFAULT_PROP_FAST_MODE = TRUE;
 static gboolean DEFAULT_PROP_DMA_FEATURE = FALSE;
+static gboolean DEFAULT_PROP_USE_MPP_PTS = TRUE;
 
 enum
 {
@@ -74,6 +75,7 @@ enum
   PROP_IGNORE_ERROR,
   PROP_FAST_MODE,
   PROP_DMA_FEATURE,
+  PROP_USE_MPP_PTS,
   PROP_LAST,
 };
 
@@ -151,6 +153,15 @@ gst_mpp_dec_set_property (GObject * object,
       self->dma_feature = g_value_get_boolean (value);
       break;
     }
+    case PROP_USE_MPP_PTS:{
+      /* 2026-08-13 B1: 暴露 use-mpp-pts 属性, 让 VFR 相机 (JPEG 1:1 无 B 帧重排)
+       * 可关闭 MPP 自动 PTS, 透传输入 PTS, 避免 pts_queue restore 补丁。 */
+      if (self->input_state)
+        GST_WARNING_OBJECT (decoder, "unable to change use-mpp-pts");
+      else
+        self->use_mpp_pts = g_value_get_boolean (value);
+      break;
+    }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -183,6 +194,9 @@ gst_mpp_dec_get_property (GObject * object,
     case PROP_DMA_FEATURE:
       g_value_set_boolean (value, self->dma_feature);
       break;
+    case PROP_USE_MPP_PTS:
+      g_value_set_boolean (value, self->use_mpp_pts);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       return;
@@ -193,6 +207,7 @@ static void
 gst_mpp_dec_stop_task (GstVideoDecoder * decoder, gboolean drain)
 {
   GstMppDecClass *klass = GST_MPP_DEC_GET_CLASS (decoder);
+  GstMppDec *self = GST_MPP_DEC (decoder);
 
   if (!GST_MPP_DEC_TASK_STARTED (decoder))
     return;
@@ -208,6 +223,32 @@ gst_mpp_dec_stop_task (GstVideoDecoder * decoder, gboolean drain)
       while (GST_TASK_STATE (task) == GST_TASK_STARTED)
         GST_TASK_WAIT (task);
       GST_OBJECT_UNLOCK (task);
+    }
+  }
+
+  /* Drain remaining output frames so buffers are properly returned
+   * to the pool before mpi->reset(), preventing pool corruption.
+   */
+  if (drain) {
+    MppFrame mframe;
+    gint timeout_ms = MPP_TIMEOUT_NON_BLOCK;
+
+    self->mpi->control (self->mpp_ctx, MPP_SET_OUTPUT_TIMEOUT, &timeout_ms);
+    while (1) {
+      self->mpi->decode_get_frame (self->mpp_ctx, &mframe);
+      if (!mframe)
+        break;
+
+      MppPacket mpkt = NULL;
+      MppMeta meta = mpp_frame_get_meta (mframe);
+
+      /* Deinit the input packet attached to this frame */
+      if (!mpp_meta_get_packet (meta, KEY_INPUT_PACKET, &mpkt)) {
+        mpp_meta_set_packet (meta, KEY_INPUT_PACKET, NULL);
+        mpp_packet_deinit (&mpkt);
+      }
+
+      mpp_frame_deinit (&mframe);
     }
   }
 
@@ -232,6 +273,11 @@ gst_mpp_dec_reset (GstVideoDecoder * decoder, gboolean drain, gboolean final)
 
   self->flushing = final;
   self->draining = FALSE;
+
+  if (self->mpp_frame) {
+    mpp_frame_deinit (&self->mpp_frame);
+    self->mpp_frame = NULL;
+  }
 
   self->mpi->reset (self->mpp_ctx);
   self->task_ret = GST_FLOW_OK;
@@ -271,8 +317,8 @@ gst_mpp_dec_start (GstVideoDecoder * decoder)
   self->decoded_frames = 0;
   self->flushing = FALSE;
 
-  /* Prefer using MPP PTS */
-  self->use_mpp_pts = TRUE;
+  /* Prefer using MPP PTS (value comes from use-mpp-pts property, initialized
+   * in gst_mpp_dec_init; do NOT override here so the property stays effective) */
   self->mpp_delta_pts = 0;
 
   g_mutex_init (&self->mutex);
@@ -1132,6 +1178,7 @@ gst_mpp_dec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
   GstBuffer *tmp;
   GstFlowReturn ret;
   MppPacket mpkt = NULL;
+  gboolean packet_has_buffer = FALSE;
 
   GST_MPP_DEC_LOCK (decoder);
 
@@ -1170,6 +1217,13 @@ gst_mpp_dec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
 
   mpp_packet_set_pts (mpkt, self->use_mpp_pts ? -1 : (gint64) frame->pts);
 
+  /* Snapshot the ownership mode while mpkt is still owned by the plugin.
+   * The MPP copy path (no attached MppBuffer) synchronously creates a new
+   * packet and leaves this original packet for the caller to release.  The
+   * zero-copy path transfers mpkt to MPP, so it must not be touched after
+   * decode_put_packet() returns. */
+  packet_has_buffer = (mpp_packet_get_buffer (mpkt) != NULL);
+
   if (GST_CLOCK_TIME_IS_VALID (frame->pts))
     self->seen_valid_pts = TRUE;
 
@@ -1182,10 +1236,14 @@ gst_mpp_dec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
   else if (G_UNLIKELY (ret != GST_FLOW_OK))
     goto drop;
 
-  /* MPP owns packet lifecycle if buffer is attached */
-  if (!mpp_packet_get_buffer (mpkt)) {
-    mpp_packet_deinit (&mpkt);
+  if (packet_has_buffer) {
+    /* Zero-copy: MPP owns mpkt after a successful send.  Do not inspect or
+     * deinit it here; the packet may already have been recycled by MPP. */
     mpkt = NULL;
+  } else {
+    /* Copy path: MPP synchronously copied the payload into a new packet, so
+     * the original packet remains owned by this function. */
+    mpp_packet_deinit (&mpkt);
   }
 
   gst_buffer_unmap (frame->input_buffer, &mapinfo);
@@ -1269,6 +1327,7 @@ gst_mpp_dec_init (GstMppDec * self)
   self->ignore_error = DEFAULT_PROP_IGNORE_ERROR;
   self->fast_mode = DEFAULT_PROP_FAST_MODE;
   self->dma_feature = DEFAULT_PROP_DMA_FEATURE;
+  self->use_mpp_pts = DEFAULT_PROP_USE_MPP_PTS;
 
   gst_video_decoder_set_packetized (decoder, TRUE);
 }
@@ -1373,6 +1432,16 @@ no_rga:
   g_object_class_install_property (gobject_class, PROP_DMA_FEATURE,
       g_param_spec_boolean ("dma-feature", "DMA feature",
           "Enable GST DMA feature", DEFAULT_PROP_DMA_FEATURE,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  /* 2026-08-13 B1: 新增 use-mpp-pts 属性。
+   * 默认 TRUE = 使用 MPP 硬件生成 PTS (H264/H265 B 帧重排需要)。
+   * VFR 相机 JPEG 流 (1:1 无重排) 设 FALSE 时透传输入 PTS,
+   * 从源头消除 jpegdec 覆盖 PTS 导致的时间戳丢失。 */
+  g_object_class_install_property (gobject_class, PROP_USE_MPP_PTS,
+      g_param_spec_boolean ("use-mpp-pts", "Use MPP PTS",
+          "Use MPP generated PTS (TRUE) or passthrough input PTS (FALSE)",
+          DEFAULT_PROP_USE_MPP_PTS,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   element_class->change_state = GST_DEBUG_FUNCPTR (gst_mpp_dec_change_state);

--- a/gst/rockchipmpp/gstmppenc.c
+++ b/gst/rockchipmpp/gstmppenc.c
@@ -428,19 +428,50 @@ gst_mpp_enc_stop_task (GstVideoEncoder * encoder, gboolean drain)
 
   GST_DEBUG_OBJECT (self, "stopping encoding thread");
 
-  /* Discard pending frames */
-  if (!drain)
-    self->pending_frames = 0;
+  /* Unconditionally discard pending frames so the encoder loop
+   * can exit via the flush path without blocking on MPP poll.
+   */
+  self->pending_frames = 0;
+
+  if (self->frames) {
+    g_list_free (self->frames);
+    self->frames = NULL;
+  }
 
   GST_MPP_ENC_BROADCAST (encoder);
 
   GST_VIDEO_ENCODER_STREAM_UNLOCK (encoder);
-  /* Wait for task thread to pause */
+  /* Wait for task thread to pause cleanly */
   if (task) {
     GST_OBJECT_LOCK (task);
     while (GST_TASK_STATE (task) == GST_TASK_STARTED)
       GST_TASK_WAIT (task);
     GST_OBJECT_UNLOCK (task);
+  }
+
+  /* Drain remaining MPP output packets so buffers are properly
+   * returned to the pool before reset, preventing pool corruption.
+   */
+  if (drain) {
+    MppPacket mpkt;
+    gint drain_count = 0;
+
+    while (1) {
+      MPP_RET ret = self->mpi->encode_get_packet (self->mpp_ctx, &mpkt);
+
+      if (ret || !mpkt)
+        break;
+
+      drain_count++;
+      MppFrame mframe;
+      MppMeta meta = mpp_packet_get_meta (mpkt);
+
+      if (!mpp_meta_get_frame (meta, KEY_INPUT_FRAME, &mframe))
+        mpp_frame_deinit (&mframe);
+
+      mpp_packet_deinit (&mpkt);
+    }
+    GST_INFO ("[TRK] DRAIN_DONE: encoder=%p drained=%d\n", self, drain_count);
   }
 
   gst_pad_stop_task (encoder->srcpad);
@@ -467,7 +498,25 @@ gst_mpp_enc_reset (GstVideoEncoder * encoder, gboolean drain, gboolean final)
   self->flushing = final;
   self->draining = FALSE;
 
+  GST_INFO ("[TRK] BEFORE_RESET: encoder=%p\n", self);
   self->mpi->reset (self->mpp_ctx);
+
+  /* Drain packets produced by MPP async thread during reset processing */
+  {
+    MppPacket mpkt;
+    gint drain_count = 0;
+    while (1) {
+      MPP_RET ret = self->mpi->encode_get_packet (self->mpp_ctx, &mpkt);
+      if (ret || !mpkt)
+        break;
+      drain_count++;
+      mpp_packet_deinit (&mpkt);
+    }
+    GST_INFO ("[TRK] POST_RESET_DRAIN: encoder=%p drained=%d\n", self,
+        drain_count);
+  }
+
+  GST_INFO ("[TRK] AFTER_RESET: encoder=%p\n", self);
   self->task_ret = GST_FLOW_OK;
   self->pending_frames = 0;
 
@@ -984,8 +1033,8 @@ gst_mpp_enc_poll_packet_locked (GstVideoEncoder * encoder)
   MppFrame mframe;
   MppPacket mpkt;
   MppMeta meta;
-  MppBuffer mbuf;
-  gint pkt_size;
+  MppBuffer mbuf = NULL;
+  gint pkt_size = 0;
 
   self->mpi->encode_get_packet (self->mpp_ctx, &mpkt);
   if (!mpkt)
@@ -1044,6 +1093,8 @@ gst_mpp_enc_poll_packet_locked (GstVideoEncoder * encoder)
   self->task_ret = gst_video_encoder_finish_frame (encoder, frame);
 
 out:
+  GST_INFO ("[TRK] PKT_POLL_DEINIT: pkt=%p mbuf=%p pkt_size=%d\n",
+      mpkt, mbuf, pkt_size);
   mpp_packet_deinit (&mpkt);
   return TRUE;
 error:
@@ -1064,7 +1115,7 @@ gst_mpp_enc_loop (GstVideoEncoder * encoder)
 
   GST_VIDEO_ENCODER_STREAM_LOCK (encoder);
 
-  if (self->flushing && !self->pending_frames) {
+  if (self->flushing) {
     GST_INFO_OBJECT (self, "flushing");
     self->task_ret = GST_FLOW_FLUSHING;
     goto out;

--- a/gst/rockchipmpp/gstmppjpegdec.c
+++ b/gst/rockchipmpp/gstmppjpegdec.c
@@ -399,36 +399,45 @@ gst_mpp_jpeg_dec_get_mpp_packet (GstVideoDecoder * decoder,
 }
 
 static gboolean
-gst_mpp_jpeg_dec_shutdown (GstVideoDecoder * decoder, gboolean drain UNUSED)
+gst_mpp_jpeg_dec_shutdown (GstVideoDecoder * decoder, gboolean drain)
 {
   GstMppJpegDec *self = GST_MPP_JPEG_DEC (decoder);
   GstMppDec *mppdec = GST_MPP_DEC (decoder);
-  MppFrame mframe;
-  MppPacket mpkt;
-  MppBuffer mbuf;
-  MppMeta meta;
-  MPP_RET ret;
 
-  GST_DEBUG_OBJECT (self, "sending EOS");
+  /* It's safe to stop decoding immediately */
+  if (!drain) {
+    mppdec->mpi->reset (mppdec->mpp_ctx);
+    return FALSE;
+  }
 
-  /* Prepare EOS packet */
-  mpp_buffer_get (self->input_group, &mbuf, 1);
-  mpp_packet_init_with_buffer (&mpkt, mbuf);
-  mpp_buffer_put (mbuf);
-  mpp_packet_set_size (mpkt, 0);
-  mpp_packet_set_length (mpkt, 0);
-  mpp_packet_set_eos (mpkt);
+  {
+    MppFrame mframe;
+    MppPacket mpkt;
+    MppBuffer mbuf;
+    MppMeta meta;
+    MPP_RET ret;
 
-  mpp_frame_init (&mframe);
-  meta = mpp_packet_get_meta (mpkt);
-  mpp_meta_set_frame (meta, KEY_OUTPUT_FRAME, mframe);
+    GST_DEBUG_OBJECT (self, "sending EOS");
 
-  while (1) {
-    ret = mppdec->mpi->decode_put_packet (mppdec->mpp_ctx, mpkt);
-    if (!ret)
-      break;
+    /* Prepare EOS packet */
+    mpp_buffer_get (self->input_group, &mbuf, 1);
+    mpp_packet_init_with_buffer (&mpkt, mbuf);
+    mpp_buffer_put (mbuf);
+    mpp_packet_set_size (mpkt, 0);
+    mpp_packet_set_length (mpkt, 0);
+    mpp_packet_set_eos (mpkt);
 
-    g_usleep (1000);
+    mpp_frame_init (&mframe);
+    meta = mpp_packet_get_meta (mpkt);
+    mpp_meta_set_frame (meta, KEY_OUTPUT_FRAME, mframe);
+
+    while (1) {
+      ret = mppdec->mpi->decode_put_packet (mppdec->mpp_ctx, mpkt);
+      if (!ret)
+        break;
+
+      g_usleep (1000);
+    }
   }
 
   return TRUE;


### PR DESCRIPTION
# rockchipmpp: fix buffer/packet lifecycle on frequent pipeline start/stop

## Problem

We run a multi-sensor kiosk product (RK3588) that starts/stops recording
pipelines (mpph264enc/mpph265enc via mppvideodec decode + encode chains)
every few seconds, 24/7.  On stock upstream code we observed:

1. **Linear memory growth / pool corruption** across pipeline restarts.
   Buffers were not returned to their MppBufferGroup before
   `mpi->reset()`, because pending output frames / encoder packets were
   never drained.  After enough restart cycles the group state is
   corrupted and allocations fail.

2. **Encoder persistent packet stale buffer reference**
   (`mpp_enc_check_pkt_buf()` assigns `pkt->buffer = buffer` raw),
   dropping the previous frame's MppBuffer reference every frame.

3. **Double-free of input packets in the zero-copy path**: when the input
   packet is attached to the output frame meta (KEY_INPUT_PACKET), both
   `dec_release_input_packet()` and the meta consumer could deinit the
   same packet ("found non-positive ref_count" followed by crash).

4. **Regression risk in `gst_mpp_dec_handle_frame()`**: after a
   successful `decode_put_packet()`, touching `mpkt` at all is unsafe for
   zero-copy packets (the address may already be recycled by the global
   packet pool shared with encoders in the same process).  The previous
   unconditional `mpkt = NULL` avoided the UAF but re-introduced a
   per-frame packet leak for plain-data (copy path) packets: MPP copies
   those synchronously inside `mpp_put_packet()` and never touches the
   original.

## Fixes

- **gstmppallocator.c**: call parent `free()` first so the MppBuffer
  refcount drops to 0 (via qdata destroy → mpp_buffer_put) *before*
  clearing ext_group; then clear cacheable group.
- **gstmppdec.c stop_task/reset**: drain remaining output frames (and
  their attached KEY_INPUT_PACKET) before `mpi->reset()`; deinit cached
  `self->mpp_frame`; unconditionally drop pending frames on non-drain
  stop so the task loop can exit.
- **gstmppenc.c stop_task/reset**: drain encoder output packets before
  reset (including packets produced by MPP async thread during reset).
- **gstmppdec.c handle_frame**: snapshot ownership mode
  (`mpp_packet_get_buffer(mpkt) != NULL`) **before** sending.  After a
  successful send:
  - zero-copy (buffer attached): MPP owns the packet — leave it alone;
  - copy path (no buffer): MPP cloned the payload synchronously, the
    original stays caller-owned — `mpp_packet_deinit(&mpkt)`.

  This fixes the per-frame packet leak (~0.5 kB/frame ≈ 1.3 GB/day at
  30 fps continuous carousel playback measured over 14 h) while keeping
  the zero-copy UAF protection.

- **gstmppjpegdec.c / ximagesink.c**: carried-along smaller corrections
  (same lifecycle patterns).

## Verification

- Per-packet allocation/free accounting via instrumented libmpp
  (PKT_NEW vs PKT_DEINIT): balanced 1820/1820 after fix; 1820/914
  (leaking ~1 packet per frame) before.
- Decode-only repro loop (uridecodebin ! queue ! fakesink, H264 and
  H265): RSS growth slope converges to noise level (<25 kB/cycle) after
  fix vs sustained +158 kB/cycle before.  Software-decoder control
  (avdec_h264) flat as baseline.
- Production display process: RSS flat at ~200 MB after 14 h (previously
  +~800 MB over the same period).

These patches are based on current master (dcbcd64).
